### PR TITLE
Update the openapi.generator plugin from version 4.0.0-beta to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
         <jar.plugin.version>3.1.1</jar.plugin.version>
         <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
         <maven-servicemix-depends.version>1.4.0</maven-servicemix-depends.version>
-        <!-- Forced to use the beta version as the latest 3.3.4 doesn't work properly with OpenAPI 3.0.2 -->
-        <openapi.generator.plugin.version>4.0.0-beta</openapi.generator.plugin.version>
+        <!-- Up rev from 4.0.0-beta to 4.0.2 fixing file path creation issues around '.' character -->
+        <openapi.generator.plugin.version>4.0.2</openapi.generator.plugin.version>
         <release.plugin.version>2.5.3</release.plugin.version>
         <resources.plugin.version>3.1.0</resources.plugin.version>
         <source.plugin.version>3.0.1</source.plugin.version>

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -230,7 +230,6 @@ components:
       required: true
       schema:
         type: string
-        format: uri
       example: ${rest.server.url}/xyz
 
   schemas:
@@ -307,7 +306,6 @@ components:
           example: 4.6.9
         url:
           type: string
-          format: uri
           description: >
             An externally accessible url where the remote system is hosting REST services that can
             can be reached. For DDF-based systems, this would be the base url for the CSW and


### PR DESCRIPTION
Update the openapi.generator plugin from version 4.0.0-beta to 4.0.2 fix issues around paths containing . characters.

REFERENCE:  https://github.com/OpenAPITools/openapi-generator/pull/1895

As part of this up rev, certain unit tests began failing related to String and URI conflicts.  After some testing, found that removing the "format: uri" tag from the yaml file resolved the issue.  I did this in an attempt to keep the method signature String given the implied unit test functionality.
I did not do a full audit and it may be recommended that we confirm this before merging by someone more familiar with the code generation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@paouelle 

#### How should this be tested? (List steps with links to updated documentation)
Run CI and review the Interfaces related to generated code

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
